### PR TITLE
Increase the precision of the measurements written to the calibration file

### DIFF
--- a/src/theodolite_collect_calib_prism.cpp
+++ b/src/theodolite_collect_calib_prism.cpp
@@ -19,6 +19,7 @@
 #include <iostream>
 #include <condition_variable>
 #include <chrono>
+#include <limits>
 
 #define RECEIVE_TIMEOUT_MS 2000
 #define TIME_BEFORE_NEXT_TX_ATTEMPT 10000
@@ -689,17 +690,20 @@ int main(int argc, char **argv)
             case SAVE:
                 {
                     ofstream output_file;
+                    output_file.precision(std::numeric_limits<double>::max_digits10);
                     output_file.open("theodolite_reference_prisms.txt", ios::out | ios::trunc);
-                    output_file << "theodolite_number , marker_number , status , elevation , azimuth , distance , sec , nsec" << std::endl;
-                    for(int i = 0; i < number_of_theodolites; i++){
-                        for(int j = 0; j < number_of_markers; j++){
-                            output_file << i+1 << " , " << j+1 
-                                << " , " << (int)markers_data_structure[i][j].status 
-                                << " , " << markers_data_structure[i][j].elevation
-                                << " , " << markers_data_structure[i][j].azimuth
-                                << " , " << markers_data_structure[i][j].meas_distance
-                                << " , " << markers_data_structure[i][j].sec
-                                << " , " << markers_data_structure[i][j].nsec << std::endl;         
+                    output_file << "theodolite_number , marker_number , status , elevation , azimuth , distance , sec , nsec\n";
+                    for(int i = 0; i < number_of_theodolites; ++i) {
+                        for(int j = 0; j < number_of_markers; ++j) {
+                          const TheodoliteMeasurement& marker = markers_data_structure[i][j];
+                          output_file
+                              << i + 1 << " , " << j + 1 << " , "
+                              << (int) marker.status << " , "
+                              << marker.elevation << " , "
+                              << marker.azimuth << " , "
+                              << marker.meas_distance << " , "
+                              << marker.sec << " , "
+                              << marker.nsec << '\n';
                         }
                     }
                     output_file.close();


### PR DESCRIPTION
When writing floating point values to a file, the default precision is set to 6 digits, e.g. the value `3.14159265358979323846` will be rounded to `3.14159`.
This fix will set the precision to the maximum digits possible, which should easily be more than 6 on a raspberry pi.